### PR TITLE
remove bad argument to use_ok

### DIFF
--- a/t/Tree/008_weak_refs.t
+++ b/t/Tree/008_weak_refs.t
@@ -9,7 +9,7 @@ plan skip_all => "Test::Memory::Cycle required for testing memory leaks" if $@;
 plan tests => 43;
 
 my $CLASS = 'Tree';
-use_ok( $CLASS, 'use_weak_refs' )
+use_ok( $CLASS )
     or Test::More->builder->BAILOUT( "Cannot load $CLASS" );
 
 { #diag "parental connections are weak";


### PR DESCRIPTION
use_ok does not accept a test name. Instead, it passes the arguments along to the given module's import method. In the past, these arguments would just be ignored if an import method didn't exist. Future versions of perl will throw errors for unhandled imports.